### PR TITLE
Allow any HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bat
-Go implement CLI, cURL-like tool for humans. Bat can be used for testing, debugging, and generally interacting with HTTP servers.
+A Go CLI, cURL-like tool for humans. Bat can be used for testing, debugging, and generally interacting with HTTP servers.
 
-Inspired from Httpie. Thanks for the author.
+Inspired by [HTTPie](https://github.com/jakubroztocil/httpie). Thanks to the author!
 
 ![](images/logo.png)
 
@@ -45,9 +45,13 @@ See also `bat --help`.
 
 ### Examples
 
-Custom [HTTP method](#http-method), [HTTP headers](#http-headers) and [JSON](#json) data:
+Basic settings - [HTTP method](#http-method), [HTTP headers](#http-headers) and [JSON](#json) data:
 
 	$ bat PUT example.org X-API-Token:123 name=John
+
+Any custom HTTP method (such as WebDAV, etc.):
+
+	$ bat -method=PROPFIND example.org name=John
 
 Submitting forms:
 

--- a/filter.go
+++ b/filter.go
@@ -12,7 +12,7 @@ func filter(args []string) []string {
 	if inSlice(strings.ToUpper(args[i]), methodList) {
 		*method = strings.ToUpper(args[i])
 		i++
-	} else if len(args) > 0 {
+	} else if len(args) > 0 && *method == "GET" {
 		for _, v := range args[1:] {
 			// defaults to either GET (with no request data) or POST (with request data).
 			// Params

--- a/http.go
+++ b/http.go
@@ -20,18 +20,7 @@ var defaultSetting = httplib.BeegoHttpSettings{
 }
 
 func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequest) {
-	switch method {
-	case "GET":
-		r = httplib.Get(url)
-	case "POST":
-		r = httplib.Post(url)
-	case "PUT":
-		r = httplib.Put(url)
-	case "HEAD":
-		r = httplib.Head(url)
-	case "DELETE":
-		r = httplib.Delete(url)
-	}
+	r = httplib.NewBeegoRequest(url, method)
 	r.Setting(defaultSetting)
 	r.Header("Accept-Encoding", "gzip, deflate")
 	if *isjson {

--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -1,4 +1,5 @@
 // Copyright 2014 beego Author. All Rights Reserved.
+// Copyright 2015 bat authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +77,7 @@ func SetDefaultSetting(setting BeegoHttpSettings) {
 }
 
 // return *BeegoHttpRequest with specific method
-func newBeegoRequest(url, method string) *BeegoHttpRequest {
+func NewBeegoRequest(url, method string) *BeegoHttpRequest {
 	var resp http.Response
 	req := http.Request{
 		Method:     method,
@@ -90,27 +91,27 @@ func newBeegoRequest(url, method string) *BeegoHttpRequest {
 
 // Get returns *BeegoHttpRequest with GET method.
 func Get(url string) *BeegoHttpRequest {
-	return newBeegoRequest(url, "GET")
+	return NewBeegoRequest(url, "GET")
 }
 
 // Post returns *BeegoHttpRequest with POST method.
 func Post(url string) *BeegoHttpRequest {
-	return newBeegoRequest(url, "POST")
+	return NewBeegoRequest(url, "POST")
 }
 
 // Put returns *BeegoHttpRequest with PUT method.
 func Put(url string) *BeegoHttpRequest {
-	return newBeegoRequest(url, "PUT")
+	return NewBeegoRequest(url, "PUT")
 }
 
 // Delete returns *BeegoHttpRequest DELETE method.
 func Delete(url string) *BeegoHttpRequest {
-	return newBeegoRequest(url, "DELETE")
+	return NewBeegoRequest(url, "DELETE")
 }
 
 // Head returns *BeegoHttpRequest with HEAD method.
 func Head(url string) *BeegoHttpRequest {
-	return newBeegoRequest(url, "HEAD")
+	return NewBeegoRequest(url, "HEAD")
 }
 
 // BeegoHttpSettings


### PR DESCRIPTION
Because they exist :-)

By the way: what do you think about adding [http2](https://github.com/bradfitz/http2) support? It will eventually be in the Go standard library (and work automatically), but for now, you should use this library.