### PR TITLE
Support form params for PUT/PATCH

### DIFF
--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -304,8 +304,8 @@ func (b *BeegoHttpRequest) buildUrl(paramBody string) {
 		return
 	}
 
-	// build POST url and body
-	if b.req.Method == "POST" && b.req.Body == nil {
+	// build POST/PUT/PATCH url and body
+	if (b.req.Method == "POST" || b.req.Method == "PUT" || b.req.Method == "PATCH") && b.req.Body == nil {
 		// with files
 		if len(b.files) > 0 {
 			pr, pw := io.Pipe()


### PR DESCRIPTION
Now -f is only support POST method, but PUT/PATCH methods need form params too.

In `net/http/request.go` I found this codes:

```
// ParseForm parses the raw query from the URL and updates r.Form.
//
// For POST or PUT requests, it also parses the request body as a form and
// put the results into both r.PostForm and r.Form.
// POST and PUT body parameters take precedence over URL query string values
// in r.Form.
//
// If the request Body's size has not already been limited by MaxBytesReader,
// the size is capped at 10MB.
//
// ParseMultipartForm calls ParseForm automatically.
// It is idempotent.
func (r *Request) ParseForm() error {
	var err error
	if r.PostForm == nil {
		if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" {
			r.PostForm, err = parsePostForm(r)
		}
...
```

It proves that PUT/PATCH alse support form params. And I really need PUT a form data in my API test.