### PR TITLE
Fixes #21, add flag to optionally support unverified SSL requests

### DIFF
--- a/bat.go
+++ b/bat.go
@@ -63,7 +63,7 @@ func init() {
 	flag.BoolVar(&download, "download", false, "Download the url content as file")
 	flag.BoolVar(&download, "d", false, "Download the url content as file")
 	flag.BoolVar(&insecureSSL, "insecure", false, "Allow connections to SSL sites without certs")
-	flag.BoolVar(&insecureSSL, "k", false, "Allow connections to SSL sites without certs")
+	flag.BoolVar(&insecureSSL, "i", false, "Allow connections to SSL sites without certs")
 	flag.StringVar(&auth, "auth", "", "HTTP authentication username:password, USER[:PASS]")
 	flag.StringVar(&auth, "a", "", "HTTP authentication username:password, USER[:PASS]")
 	flag.StringVar(&proxy, "proxy", "", "Proxy host and port, PROXY_URL")
@@ -306,7 +306,7 @@ flags:
   -f, -form=false             Submitting the data as a form
   -j, -json=true              Send the data in a JSON object
   -p, -pretty=true            Print Json Pretty Fomat
-  -k, -insecure               Allow connections to SSL sites without certs
+  -i, -insecure=false         Allow connections to SSL sites without certs
   -proxy=PROXY_URL            Proxy with host and port
   -print="A"                  String specifying what the output should contain, default will print all infomation
          "H" request headers

--- a/bat.go
+++ b/bat.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -38,6 +39,7 @@ var (
 	form             bool
 	pretty           bool
 	download         bool
+	insecureSSL      bool
 	auth             string
 	proxy            string
 	printV           string
@@ -60,6 +62,8 @@ func init() {
 	flag.BoolVar(&form, "f", false, "Submitting as a form")
 	flag.BoolVar(&download, "download", false, "Download the url content as file")
 	flag.BoolVar(&download, "d", false, "Download the url content as file")
+	flag.BoolVar(&insecureSSL, "insecure", false, "Allow connections to SSL sites without certs")
+	flag.BoolVar(&insecureSSL, "k", false, "Allow connections to SSL sites without certs")
 	flag.StringVar(&auth, "auth", "", "HTTP authentication username:password, USER[:PASS]")
 	flag.StringVar(&auth, "a", "", "HTTP authentication username:password, USER[:PASS]")
 	flag.StringVar(&proxy, "proxy", "", "Proxy host and port, PROXY_URL")
@@ -128,6 +132,10 @@ func main() {
 	if u.User != nil {
 		password, _ := u.User.Password()
 		httpreq.GetRequest().SetBasicAuth(u.User.Username(), password)
+	}
+	// Insecure SSL Support
+	if insecureSSL {
+		httpreq.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	}
 	// Proxy Support
 	if proxy != "" {
@@ -298,6 +306,7 @@ flags:
   -f, -form=false             Submitting the data as a form
   -j, -json=true              Send the data in a JSON object
   -p, -pretty=true            Print Json Pretty Fomat
+  -k, -insecure               Allow connections to SSL sites without certs
   -proxy=PROXY_URL            Proxy with host and port
   -print="A"                  String specifying what the output should contain, default will print all infomation
          "H" request headers


### PR DESCRIPTION
As an easy fix to #21, I kept the flag/description the same as with curl, though I dislike `-k` as it doesn't really describe the functionality. `-i` may be better. It's used for including headers in the output of curl, and bat does not do that via a flag.