### PR TITLE
Add ansi-color support for windows

### DIFF
--- a/bat.go
+++ b/bat.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/shiena/ansicolor"
 	"io"
 	"io/ioutil"
 	"log"
@@ -231,70 +232,39 @@ func main() {
 		return
 	}
 
-	if runtime.GOOS != "windows" {
-		fi, err := os.Stdout.Stat()
-		if err != nil {
-			panic(err)
-		}
-		if fi.Mode()&os.ModeDevice == os.ModeDevice {
-			if printV == "A" || printV == "H" || printV == "B" {
-				dump := httpreq.DumpRequest()
-				if printV == "B" {
-					dps := strings.Split(string(dump), "\n")
-					for i, line := range dps {
-						if len(strings.Trim(line, "\r\n ")) == 0 {
-							dump = []byte(strings.Join(dps[i:], "\n"))
-							break
-						}
-					}
-				}
-				fmt.Println(ColorfulRequest(string(dump)))
-				fmt.Println("")
-			}
-			if printV == "A" || printV == "h" {
-				fmt.Println(Color(res.Proto, Magenta), Color(res.Status, Green))
-				for k, v := range res.Header {
-					fmt.Println(Color(k, Gray), ":", Color(strings.Join(v, " "), Cyan))
-				}
-				fmt.Println("")
-			}
-			if printV == "A" || printV == "b" {
-				body := formatResponseBody(res, httpreq, pretty)
-				fmt.Println(ColorfulResponse(body, res.Header.Get("Content-Type")))
-			}
-		} else {
-			body := formatResponseBody(res, httpreq, pretty)
-			_, err = os.Stdout.WriteString(body)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-	} else {
-		if printV == "A" || printV == "H" || printV == "B" {
-			dump := httpreq.DumpRequest()
-			if printV == "B" {
-				dps := strings.Split(string(dump), "\n")
-				for i, line := range dps {
-					if len(strings.Trim(line, "\r\n ")) == 0 {
-						dump = []byte(strings.Join(dps[i:], "\n"))
-						break
-					}
+	fi, _ := os.Stdout.Stat()
+
+	if fi != nil && fi.Mode()&os.ModeCharDevice == 0 {
+		body := formatResponseBody(res, httpreq, pretty)
+		fmt.Print(body)
+		return
+	}
+
+	out := ansicolor.NewAnsiColorWriter(os.Stdout)
+	if printV == "A" || printV == "H" || printV == "B" {
+		dump := httpreq.DumpRequest()
+		if printV == "B" {
+			dps := strings.Split(string(dump), "\n")
+			for i, line := range dps {
+				if len(strings.Trim(line, "\r\n ")) == 0 {
+					dump = []byte(strings.Join(dps[i:], "\n"))
+					break
 				}
 			}
-			fmt.Println(string(dump))
-			fmt.Println("")
 		}
-		if printV == "A" || printV == "h" {
-			fmt.Println(res.Proto, res.Status)
-			for k, v := range res.Header {
-				fmt.Println(k, ":", strings.Join(v, " "))
-			}
-			fmt.Println("")
+		fmt.Fprintln(out, ColorfulRequest(string(dump)))
+		fmt.Fprintln(out, "")
+	}
+	if printV == "A" || printV == "h" {
+		fmt.Fprintln(out, Color(res.Proto, Magenta), Color(res.Status, Green))
+		for k, v := range res.Header {
+			fmt.Fprintln(out, Color(k, Gray), ":", Color(strings.Join(v, " "), Cyan))
 		}
-		if printV == "A" || printV == "b" {
-			body := formatResponseBody(res, httpreq, pretty)
-			fmt.Println(body)
-		}
+		fmt.Fprintln(out, "")
+	}
+	if printV == "A" || printV == "b" {
+		body := formatResponseBody(res, httpreq, pretty)
+		fmt.Fprintln(out, ColorfulResponse(body, res.Header.Get("Content-Type")))
 	}
 }
 

--- a/http.go
+++ b/http.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -109,7 +108,7 @@ func formatResponseBody(res *http.Response, httpreq *httplib.BeegoHttpRequest, p
 	if err != nil {
 		log.Fatalln("can't get the url", err)
 	}
-	fmt.Println("")
+
 	if pretty && strings.Contains(res.Header.Get("Content-Type"), contentJsonRegex) {
 		var output bytes.Buffer
 		err := json.Indent(&output, body, "", "  ")


### PR DESCRIPTION
Integrated [shiena/ansicolor](https://github.com/shiena/ansicolor).

We need to change color scheme a little bit. I am not a windows guy but as far as I can see windows shell does not support ansi codes like 90, 91. But codes like 30, 31, ... seem ok.

Taking #25 also into consideration, it may be good to rethink the built-in color scheme for larger platform support.