### PR TITLE
corrected misspelled 'winodowns'

### DIFF
--- a/bat.go
+++ b/bat.go
@@ -201,7 +201,7 @@ func main() {
 		if err != nil {
 			log.Fatal("can't create file", err)
 		}
-		if runtime.GOOS != "windowns" {
+		if runtime.GOOS != "windows" {
 			fmt.Println(Color(res.Proto, Magenta), Color(res.Status, Green))
 			for k, v := range res.Header {
 				fmt.Println(Color(k, Gray), ":", Color(strings.Join(v, " "), Cyan))


### PR DESCRIPTION
I saw that windows was misspelled. Thought I should make the correction.