### PR TITLE
Fixed wrong order of params parsing

### DIFF
--- a/http.go
+++ b/http.go
@@ -58,15 +58,6 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 			jsonmap[strs[0]] = toRealType(strs[1])
 			continue
 		}
-		// Headers
-		strs = strings.Split(args[i], ":")
-		if len(strs) >= 2 {
-			if strs[0] == "Host" {
-				r.SetHost(strings.Join(strs[1:], ":"))
-			}
-			r.Header(strs[0], strings.Join(strs[1:], ":"))
-			continue
-		}
 		// Params
 		strs = strings.Split(args[i], "=")
 		if len(strs) == 2 {
@@ -95,6 +86,15 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 				log.Fatal("file upload only support in forms style: -f=true")
 			}
 			r.PostFile(strs[0], strs[1])
+			continue
+		}
+		// Headers
+		strs = strings.Split(args[i], ":")
+		if len(strs) >= 2 {
+			if strs[0] == "Host" {
+				r.SetHost(strings.Join(strs[1:], ":"))
+			}
+			r.Header(strs[0], strings.Join(strs[1:], ":"))
 			continue
 		}
 	}


### PR DESCRIPTION
This pull request will fix params parse error like this:

```
bat -f POST ":8391/register" volume_host="http://127.0.0.1:8292"
```

This request's form body will lose the content what you want:

```
volume_host=http%3A%2F%2F127.0.0.1%3A8292
```

but the header will add a pair which you don't want:

```
Volume_host=http: //127.0.0.1:8292
```

Adjust the parse order in `http.go`. Move the Headers' parsing behind the Params' will fix this bug.