### PR TITLE
Support multi print params like '-print=HBhb'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Submitting forms:
 	
 See the request that is being sent using one of the output options:
 
-	$ bat -print="H" example.org
+	$ bat -print="Hhb" example.org
 
 Use Github API to post a comment on an issue with authentication:
 

--- a/color.go
+++ b/color.go
@@ -28,7 +28,7 @@ func ColorStart(color uint8) string {
 
 func ColorfulRequest(str string) string {
 	lines := strings.Split(str, "\n")
-	if printV == "A" || printV == "H" {
+	if printOption&printReqHeader == printReqHeader {
 		strs := strings.Split(lines[0], " ")
 		strs[0] = Color(strs[0], Magenta)
 		strs[1] = Color(strs[1], Cyan)


### PR DESCRIPTION
In some cases, we need display parts of req & resp info.
Like req's HEADER and resp's BODY:
We can use `-print=Hb` to get these.
Or req's BODY and resp's HEADER:
Use `-print=Bh`.
While -print=A is still supported.