### PR TITLE
Trim quotes around Content-Disposition:filename values

### DIFF
--- a/bat.go
+++ b/bat.go
@@ -223,8 +223,12 @@ func main() {
 			for _, f := range fls {
 				f = strings.TrimSpace(f)
 				if strings.HasPrefix(f, "filename=") {
+					// Remove 'filename='
 					f = strings.TrimLeft(f, "filename=")
-					fl = strings.Trim(f, "\"' ")
+
+					// Remove quotes and spaces from either end
+					f = strings.TrimLeft(f, "\"' ")
+					fl = strings.TrimRight(f, "\"' ")
 				}
 			}
 		}

--- a/bat.go
+++ b/bat.go
@@ -223,7 +223,8 @@ func main() {
 			for _, f := range fls {
 				f = strings.TrimSpace(f)
 				if strings.HasPrefix(f, "filename=") {
-					fl = strings.TrimLeft(f, "filename=")
+					f = strings.TrimLeft(f, "filename=")
+					fl = strings.Trim(f, "\"' ")
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the bug from #40.

The issue was that if the server sets a `Content-Disposition` header to suggest a file name during a download and the suggestion is wrapped in quotes, these quotes will not be striped away when saving the resulting file.

I simply added a line to trim both double and single quotes as well as spaces from either end of the file name. Not 100% sure if spaces could occur in this case but I thought better safe than sorry.