### PR TITLE
Use jsoncolor package to colorize JSON

### DIFF
--- a/bat.go
+++ b/bat.go
@@ -303,7 +303,7 @@ func main() {
 			}
 			if printOption&printRespBody == printRespBody {
 				body := formatResponseBody(res, httpreq, pretty)
-				fmt.Println(ColorfulResponse(body, res.Header.Get("Content-Type")))
+				fmt.Println(ColorfulResponse(body, res.Header.Get("Content-Type"), pretty))
 			}
 		} else {
 			body := formatResponseBody(res, httpreq, pretty)

--- a/http.go
+++ b/http.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -110,15 +109,6 @@ func formatResponseBody(res *http.Response, httpreq *httplib.BeegoHttpRequest, p
 		log.Fatalln("can't get the url", err)
 	}
 	fmt.Println("")
-	if pretty && strings.Contains(res.Header.Get("Content-Type"), contentJsonRegex) {
-		var output bytes.Buffer
-		err := json.Indent(&output, body, "", "  ")
-		if err != nil {
-			log.Fatal("Response Json Indent: ", err)
-		}
-
-		return output.String()
-	}
 
 	return string(body)
 }


### PR DESCRIPTION
[jsoncolor](https://github.com/nwidger/jsoncolor) uses [github.com/fatih/color](https://github.com/fatih/color) for colored output and can be
easily configured to use separate colors for each JSON token.  This PR
preserves all the existing color choices.  I removed the call to
json.Indent in formatResponseBody since jsoncolor can also indent the
JSON, respecting the -pretty flag.
