### PR TITLE
use a real regex for the json content-type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ Simple example:
 	    "email": "john@example.org"
 	}
 
+Even custom/vendored media types that have a json format are getting detected, as long as they implement a json type response and contain a `json` in their declared form:
+
+	$ bat GET example.org/user/1 Accept:application/vnd.example.v2.0+json
+	GET / HTTP/1.1
+	Accept: application/vnd.example.v2.0+json
+	Accept-Encoding: gzip, deflate
+	Content-Type: application/vnd.example.v2.0+json
+	Host: example.org
+
+	{
+	    "name": "John",
+	    "email": "john@example.org"
+	}
+
 Non-string fields use the := separator, which allows you to embed raw JSON into the resulting object. Text and raw JSON files can also be embedded into fields using =@ and :=@:
 
 	$ bat PUT api.example.com/person/1 \

--- a/bat.go
+++ b/bat.go
@@ -60,7 +60,7 @@ var (
 	method           = flag.String("method", "GET", "HTTP method")
 	URL              = flag.String("url", "", "HTTP request URL")
 	jsonmap          map[string]interface{}
-	contentJsonRegex = `application/json`
+	contentJsonRegex = `application/(.*)json`
 )
 
 func init() {

--- a/color.go
+++ b/color.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"regexp"
 	"strings"
 )
 
@@ -48,7 +50,11 @@ func ColorfulRequest(str string) string {
 }
 
 func ColorfulResponse(str, contenttype string) string {
-	if strings.Contains(contenttype, contentJsonRegex) {
+	match, err := regexp.MatchString(contentJsonRegex, contenttype)
+	if err != nil {
+		log.Fatalln("failed to compile regex", err)
+	}
+	if match {
 		str = ColorfulJson(str)
 	} else {
 		str = ColorfulHTML(str)

--- a/http.go
+++ b/http.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -110,7 +111,11 @@ func formatResponseBody(res *http.Response, httpreq *httplib.BeegoHttpRequest, p
 		log.Fatalln("can't get the url", err)
 	}
 	fmt.Println("")
-	if pretty && strings.Contains(res.Header.Get("Content-Type"), contentJsonRegex) {
+	match, err := regexp.MatchString(contentJsonRegex, res.Header.Get("Content-Type"))
+	if err != nil {
+		log.Fatalln("failed to compile regex", err)
+	}
+	if pretty && match {
 		var output bytes.Buffer
 		err := json.Indent(&output, body, "", "  ")
 		if err != nil {


### PR DESCRIPTION
this enables to match custom/vendored types that have a json format
like e.g.:
  application/vnd.bat.v0.0.2+json

this is a widespread common pattern, and if you talk to an API that
only accepts this mediatype, the output will be returned as a
normal string, even if it can be decoded as json.

this patch enables to print a pretty version of that json response
by default, so it gets treated like any default application/json
type.