### PR TITLE
handle param's values which contains "="

### DIFF
--- a/http.go
+++ b/http.go
@@ -37,7 +37,7 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 	}
 	for i := range args {
 		// Json raws
-		strs := strings.Split(args[i], ":=")
+		strs := strings.SplitN(args[i], ":=", 2)
 		if len(strs) == 2 {
 			if strings.HasPrefix(strs[1], "@") {
 				f, err := os.Open(strings.TrimLeft(strs[1], "@"))
@@ -60,7 +60,7 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 			continue
 		}
 		// Params
-		strs = strings.Split(args[i], "=")
+		strs = strings.SplitN(args[i], "=", 2)
 		if len(strs) == 2 {
 			if strings.HasPrefix(strs[1], "@") {
 				f, err := os.Open(strings.TrimLeft(strs[1], "@"))
@@ -81,7 +81,7 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 			continue
 		}
 		// files
-		strs = strings.Split(args[i], "@")
+		strs = strings.SplitN(args[i], "@", 2)
 		if len(strs) == 2 {
 			if !form {
 				log.Fatal("file upload only support in forms style: -f=true")


### PR DESCRIPTION
Before this fix 
```
bat POST https://issues.apache.org/jira/rest/api/2/search jql="project = AGILA" startAt=0 maxResults=0
```

results in ignoring the `jql` param

with this fix it handle correctly `=` symbol in param's value.