### PR TITLE
Add Docker and don't print request body if empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.8
+
+ADD . /go/src/github.com/astaxie/bat
+
+RUN go install github.com/astaxie/bat
+
+ENTRYPOINT ["/go/bin/bat"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Inspired by [Httpie](https://github.com/jakubroztocil/httpie). Thanks to the aut
 - [Authentication](#authentication)
 - [Proxies](#proxies)
 
+## Docker
+
+    # Build the docker image
+	$ docker built -t astaxie/bat .
+	
+	# Run bat in a container
+	$ docker run --rm -it --net=host astaxie/bat exemple.org
+
 ## Main Features
 
 - Expressive and intuitive syntax

--- a/bat.go
+++ b/bat.go
@@ -291,8 +291,10 @@ func main() {
 				fmt.Println("")
 			}
 			if printOption&printReqBody == printReqBody {
-				fmt.Println(string(dumpBody))
-				fmt.Println("")
+				if string(dumpBody) != "\r\n" {
+					fmt.Println(string(dumpBody))
+					fmt.Println("")
+				}
 			}
 			if printOption&printRespHeader == printRespHeader {
 				fmt.Println(Color(res.Proto, Magenta), Color(res.Status, Green))


### PR DESCRIPTION
I add a simple dockerfile and add on [my docker hub](https://hub.docker.com/r/alebatt/bat/)
(can you add it on your docker hub ? to avoid build)

Plus bat was printing too many empty line when the request body was empty.