### PR TITLE
fix when including @ in the value of a property in json body

### DIFF
--- a/http.go
+++ b/http.go
@@ -47,7 +47,7 @@ func getHTTP(method string, url string, args []string) (r *httplib.BeegoHttpRequ
 		}
 		// files
 		strs = strings.SplitN(args[i], "@", 2)
-		if len(strs) == 2 {
+		if !*isjson && len(strs) == 2 {
 			if !form {
 				log.Fatal("file upload only support in forms style: -f=true")
 			}


### PR DESCRIPTION
When doing a POST/PATCH or  PUT request I couldn't include @ in the value of a json property. Hopefully this will fix that issue and not break any other things.